### PR TITLE
Add a footer slot

### DIFF
--- a/src/VueJsoneditor.vue
+++ b/src/VueJsoneditor.vue
@@ -2,6 +2,11 @@
     <div class="jsoneditor-container" :class="{'max-box':max,'min-box':!max}" :style="getHeight">
         <div ref="jsoneditor" class="jsoneditor-box"></div>
         <button type="button" @click="max = !max" class="max-btn" size="mini" v-if="options.mode == 'code' && plus"></button>
+        <div class="footer">
+          <div class="json-footer">
+            <slot name="footer" />
+          </div>
+        </div>
     </div>
 </template>
 


### PR DESCRIPTION
This modifications allows to append something at the bottom of the editor pannel, using a slot named "footer", as in this example.
<img width="576" alt="Capture d’écran 2020-09-01 à 14 19 23" src="https://user-images.githubusercontent.com/24251307/91850637-24668180-ec5e-11ea-9c68-7848fffc443c.png">
